### PR TITLE
Logging

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,9 +5,9 @@ Handlebars for XP web frontends change log
 
 ## 0.4.0 / 2021-02-14
 
-* Added default logging implementation which echoes the content. When
-  using the development webserver, this will show the debug page - for
-  production, the content will be written to server's standard output.
+* Merged PR #2: Logging. Using the development webserver, this will show
+  the debug page - for production, the content will be written to the
+  server's standard output.
   (@thekid)
 
 ## 0.3.0 / 2021-02-13

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ Handlebars for XP web frontends change log
 
 ## ?.?.? / ????-??-??
 
+## 0.4.0 / 2021-02-14
+
+* Added default logging implementation which echoes the content. When
+  using the development webserver, this will show the debug page - for
+  production, the content will be written to server's standard output.
+  (@thekid)
+
 ## 0.3.0 / 2021-02-13
 
 * Add support for milliseconds resolution in timestamps to `date` helper,

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The `log` helper will echo the arguments passed to it:
 
 ```handlebars
 {{log user}}
+{{log "User profile:" user}}
 ```
 
 When using the development webserver, this shows the debug page:

--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ When using the development webserver, this shows the debug page:
 
 In production environments, logs will end up on the server's standard output:
 
-![Console outpit](https://user-images.githubusercontent.com/696742/107874105-838c1b80-6eb7-11eb-8c7e-ee257ef1d92d.png)
+![Console output](https://user-images.githubusercontent.com/696742/107874105-838c1b80-6eb7-11eb-8c7e-ee257ef1d92d.png)

--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ The `date` helper accepts anything the `util.Date` class accepts as constructor 
 {{date created}}
 {{date created format="d.m.Y"}}
 ```
+
+### Logging
+
+The `log` helper will echo the arguments passed to it:
+
+```handlebars
+{{log user}}
+```
+
+When using the development webserver, this shows the debug page:
+
+![Debug page](https://user-images.githubusercontent.com/696742/107873960-89cdc800-6eb6-11eb-954b-8b00324cce74.png)
+
+In production environments, logs will end up on the server's standard output:
+
+![Console outpit](https://user-images.githubusercontent.com/696742/107874105-838c1b80-6eb7-11eb-8c7e-ee257ef1d92d.png)

--- a/src/main/php/web/frontend/Handlebars.class.php
+++ b/src/main/php/web/frontend/Handlebars.class.php
@@ -2,7 +2,7 @@
 
 use com\github\mustache\TemplateLoader;
 use com\handlebarsjs\{HandlebarsEngine, FilesIn};
-use util\Date;
+use util\{Date, Objects};
 
 /**
  * Handlebars-based template engine for web frontends.
@@ -22,6 +22,11 @@ class Handlebars implements Templates {
   public function __construct($templates) {
     $this->backing= (new HandlebarsEngine())
       ->withTemplates($templates instanceof TemplateLoader ? $templates : new FilesIn($templates))
+      ->withLogger(function($args) {
+        foreach ($args as $arg) {
+          echo '  ', Objects::stringOf($arg, '  '), "\n";
+        }
+      })
       ->withHelper('encode', function($in, $context, $options) {
         return rawurlencode($options[0] ?? '');
       })

--- a/src/main/php/web/frontend/Handlebars.class.php
+++ b/src/main/php/web/frontend/Handlebars.class.php
@@ -23,9 +23,11 @@ class Handlebars implements Templates {
     $this->backing= (new HandlebarsEngine())
       ->withTemplates($templates instanceof TemplateLoader ? $templates : new FilesIn($templates))
       ->withLogger(function($args) {
+        echo '  ';
         foreach ($args as $arg) {
-          echo '  ', Objects::stringOf($arg, '  '), "\n";
+          echo is_string($arg) ? $arg : Objects::stringOf($arg, '  '), ' ';
         }
+        echo "\n";
       })
       ->withHelper('encode', function($in, $context, $options) {
         return rawurlencode($options[0] ?? '');

--- a/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
@@ -154,9 +154,9 @@ class HandlebarsTest {
   #[Test]
   public function logging_echoes_content() {
     ob_start();
-    $this->transform('{{log "Hello" user}}', ['user' => 'test']);
+    $this->transform('{{log "User:" user}}', ['user' => ['id' => 'test']]);
     $logged= ob_get_clean();
 
-    Assert::equals("  \"Hello\"\n  \"test\"\n", $logged);
+    Assert::equals("  User: [\n    id => \"test\"\n  ] \n", $logged);
   }
 }

--- a/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
@@ -150,4 +150,13 @@ class HandlebarsTest {
       'empty'   => [],
     ]));
   }
+
+  #[Test]
+  public function logging_echoes_content() {
+    ob_start();
+    $this->transform('{{log "Hello" user}}', ['user' => 'test']);
+    $logged= ob_get_clean();
+
+    Assert::equals("  \"Hello\"\n  \"test\"\n", $logged);
+  }
 }


### PR DESCRIPTION
The `log` helper will echo the arguments passed to it:

```handlebars
{{log user}}
{{log "User profile:" user}}
```

When using the development webserver, this shows the debug page:

![Debug page](https://user-images.githubusercontent.com/696742/107873960-89cdc800-6eb6-11eb-954b-8b00324cce74.png)

In production environments, logs will end up on the server's standard output:

![Console output](https://user-images.githubusercontent.com/696742/107874105-838c1b80-6eb7-11eb-8c7e-ee257ef1d92d.png)
