### PR TITLE
Add web.frontend.helpers.Numbers to format numbers and percentages

### DIFF
--- a/src/main/php/web/frontend/helpers/Numbers.class.php
+++ b/src/main/php/web/frontend/helpers/Numbers.class.php
@@ -40,5 +40,20 @@ class Numbers extends Extension {
         $this->thousands
       )]);
     };
+    yield 'count' => function($in, $context, $options) {
+      $n= $options[0];
+      if (0 === $n) {
+        return $options[1];
+      } else if (1 === $n) {
+        return $options[2];
+      } else {
+        return strtr($options[3], ['#' => number_format(
+          $n,
+          $options['decimals'] ?? strlen(strstr($n, '.')) - 1,
+          $this->decimals,
+          $this->thousands
+        )]);
+      }
+    };
   }
 }

--- a/src/main/php/web/frontend/helpers/Numbers.class.php
+++ b/src/main/php/web/frontend/helpers/Numbers.class.php
@@ -1,0 +1,44 @@
+<?php namespace web\frontend\helpers;
+
+/** Number formatting helper */
+class Numbers extends Extension {
+  private $decimals, $thousands;
+
+  /**
+   * Creates new numbers formatting helper with given decimals and
+   * thousands separators.
+   *
+   * @see    https://www.php.net/number_format
+   * @see    https://docs.microsoft.com/en-us/globalization/locale/number-formatting
+   * @param  string $decimals
+   * @param  string $thousands
+   * @param  string $percent
+   */
+  public function __construct($decimals= '.', $thousands= '', $percent= '#%') {
+    $this->decimals= $decimals;
+    $this->thousands= $thousands;
+    $this->percent= $percent;
+  }
+
+  /** @return iterable */
+  public function helpers() {
+    yield 'number' => function($in, $context, $options) {
+      $n= $options[0];
+      return number_format(
+        $n,
+        $options['decimals'] ?? strlen(strstr($n, '.')) - 1,
+        $this->decimals,
+        $this->thousands
+      );
+    };
+    yield 'percent'  => function($in, $context, $options) {
+      $n= $options[0] * 100;
+      return strtr($this->percent, ['#' => number_format(
+        $n,
+        $options['decimals'] ?? strlen(strstr($n, '.')) - 1,
+        $this->decimals,
+        $this->thousands
+      )]);
+    };
+  }
+}

--- a/src/test/php/web/frontend/unittest/NumbersTest.class.php
+++ b/src/test/php/web/frontend/unittest/NumbersTest.class.php
@@ -45,7 +45,7 @@ class NumbersTest extends HandlebarsTest {
     Assert::equals($expected, $this->transform('{{percent fixture decimals=1}}', ['fixture' => $number]));
   }
 
-  #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items']])]
+  #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items'], [1000, '1,000 items']])]
   public function count($number, $expected) {
     Assert::equals($expected, $this->transform('{{count fixture "no items" "one item" "# items"}}', ['fixture' => $number]));
   }

--- a/src/test/php/web/frontend/unittest/NumbersTest.class.php
+++ b/src/test/php/web/frontend/unittest/NumbersTest.class.php
@@ -44,4 +44,9 @@ class NumbersTest extends HandlebarsTest {
   public function percentages_with_decimals($number, $expected) {
     Assert::equals($expected, $this->transform('{{percent fixture decimals=1}}', ['fixture' => $number]));
   }
+
+  #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items']])]
+  public function count($number, $expected) {
+    Assert::equals($expected, $this->transform('{{count fixture "no items" "one item" "# items"}}', ['fixture' => $number]));
+  }
 }

--- a/src/test/php/web/frontend/unittest/NumbersTest.class.php
+++ b/src/test/php/web/frontend/unittest/NumbersTest.class.php
@@ -1,0 +1,47 @@
+<?php namespace web\frontend\unittest;
+
+use unittest\{Assert, Test, Values};
+use web\frontend\helpers\Numbers;
+
+class NumbersTest extends HandlebarsTest {
+
+  /** @return web.frontend.Extension[] */
+  protected function extensions() {
+    return [new Numbers('.', ',', '#%')];
+  }
+
+  #[Test, Values([[1, '1'], [1000, '1,000'], [-1000, '-1,000'], [1000000, '1,000,000'], [1234.56, '1,234.56']])]
+  public function thousands_separator($number, $expected) {
+    Assert::equals($expected, $this->transform('{{number fixture}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '1'], [0.5, '0.5'], [-0.5, '-0.5'], [0.123456789, '0.123456789']])]
+  public function decimals_separator($number, $expected) {
+    Assert::equals($expected, $this->transform('{{number fixture}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '1.00'], [0.5, '0.50'], [-0.5, '-0.50'], [0.123456789, '0.12'], [0.129, '0.13']])]
+  public function two_decimals($number, $expected) {
+    Assert::equals($expected, $this->transform('{{number fixture decimals=2}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '1'], [0.5, '1'], [-0.5, '-1'], [0.123456789, '0']])]
+  public function no_decimals($number, $expected) {
+    Assert::equals($expected, $this->transform('{{number fixture decimals=0}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '100%'], [0.5, '50%'], [0.125, '12.5%']])]
+  public function percentages($number, $expected) {
+    Assert::equals($expected, $this->transform('{{percent fixture}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '100%'], [0.5, '50%'], [0.125, '13%']])]
+  public function percentages_without_decimals($number, $expected) {
+    Assert::equals($expected, $this->transform('{{percent fixture decimals=0}}', ['fixture' => $number]));
+  }
+
+  #[Test, Values([[1, '100.0%'], [0.5, '50.0%'], [0.125, '12.5%']])]
+  public function percentages_with_decimals($number, $expected) {
+    Assert::equals($expected, $this->transform('{{percent fixture decimals=1}}', ['fixture' => $number]));
+  }
+}


### PR DESCRIPTION
See #1 

## Formatting numbers

```php
// Default: Use "." as decimal separator, no thousands separator
$engine= new Handlebars($templates, new Numbers());

// German notation
$engine= new Handlebars($templates, new Numbers(decimals: ',', thousands: '.'));
```

Given a *(float)1234.5*, the results are as follows:

```handlebars
{{number n}}            => 1,234.5 (Uses as many decimals as present)
{{number n decimals=0}} => 1,235 (Rounds)
{{number n decimals=2}} => 1,234.50
```

## Formatting percentages

```php
// Default: Use "%" sign directly behind number
$engine= new Handlebars($templates, new Numbers());

// German notation, including a space between number and "%" sign
$engine= new Handlebars($templates, new Numbers(percent: '# %'));
```

Given a *(float)0.749*, the results are as follows:

```handlebars
{{percent n}}            => 74.9% (Uses as many decimals as present)
{{percent n decimals=0}} => 75% (Rounds)
{{percent n decimals=2}} => 74.90%
```

## Formatting counts

```handlebars
{{count n "no items" "one item" "# items"}}
```

Handles special cases for 0 items or 1 item.