### PR TITLE
Add helper functions extension

### DIFF
--- a/src/main/php/web/frontend/helpers/Functions.class.php
+++ b/src/main/php/web/frontend/helpers/Functions.class.php
@@ -1,0 +1,19 @@
+<?php namespace web\frontend\helpers;
+
+/** Helper functions */
+class Functions extends Extension {
+
+  /**
+   * Creates new functions extension
+   *
+   * @param  [:function(com.github.mustache.Node, com.github.mustache.Context, mixed[]): mixed] $named
+   */
+  public function __construct(array $named) {
+    $this->named= $named;
+  }
+
+  /** @return iterable */
+  public function helpers() {
+    return $this->named;
+  }
+}

--- a/src/main/php/web/frontend/helpers/Functions.class.php
+++ b/src/main/php/web/frontend/helpers/Functions.class.php
@@ -2,6 +2,7 @@
 
 /** Helper functions */
 class Functions extends Extension {
+  private $named;
 
   /**
    * Creates new functions extension

--- a/src/test/php/web/frontend/unittest/FunctionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/FunctionsTest.class.php
@@ -1,0 +1,24 @@
+<?php namespace web\frontend\unittest;
+
+use unittest\{Assert, Test};
+use web\frontend\helpers\Functions;
+
+class FunctionsTest extends HandlebarsTest {
+
+  /** @return web.frontend.Extension[] */
+  protected function extensions() {
+    return [new Functions([
+      'top' => function($node, $context, $args) {
+        return array_slice($args[1], 0, $args[0]);
+      }
+    ])];
+  }
+
+  #[Test]
+  public function top_three() {
+    Assert::equals(
+      'ABC',
+      $this->transform('{{#each (top 3 people)}}{{.}}{{/each}}', ['people' => ['A', 'B', 'C', 'D']])
+    );
+  }
+}

--- a/src/test/php/web/frontend/unittest/FunctionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/FunctionsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\frontend\unittest;
 
-use unittest\{Assert, Test};
+use unittest\{Assert, Test, Values};
 use web\frontend\helpers\Functions;
 
 class FunctionsTest extends HandlebarsTest {
@@ -8,17 +8,39 @@ class FunctionsTest extends HandlebarsTest {
   /** @return web.frontend.Extension[] */
   protected function extensions() {
     return [new Functions([
-      'top' => function($node, $context, $args) {
-        return array_slice($args[1], 0, $args[0]);
+      'top' => function($node, $context, $options) {
+        return array_slice($options[1], 0, $options[0]);
+      },
+      'and' => function($node, $context, $options) {
+        $list= $options[0];
+        switch (sizeof($list)) {
+          case 0: return '';
+          case 1: return $list[0];
+          case 2: return $list[0].' and '.$list[1];
+          default: $last= array_pop($list); return implode(', ', $list).' and '.$last;
+        }
       }
     ])];
   }
 
+  /** @return iterable */
+  private function lists() {
+    yield [[], ''];
+    yield [['A'], 'A'];
+    yield [['A', 'B'], 'A and B'];
+    yield [['A', 'B', 'C'], 'A, B and C'];
+    yield [['A', 'B', 'C', 'D'], 'A, B, C and D'];
+  }
+
   #[Test]
   public function top_three() {
-    Assert::equals(
-      'ABC',
-      $this->transform('{{#each (top 3 people)}}{{.}}{{/each}}', ['people' => ['A', 'B', 'C', 'D']])
-    );
+    Assert::equals('ABC', $this->transform('{{#each (top 3 people)}}{{.}}{{/each}}', [
+      'people' => ['A', 'B', 'C', 'D']
+    ]));
+  }
+
+  #[Test, Values('lists')]
+  public function and($list, $result) {
+    Assert::equals($result, $this->transform('{{and people}}', ['people' => $list]));
   }
 }


### PR DESCRIPTION
PHP:

```php
use web\frontend\{Frontend, Handlebars};
use web\frontend\extension\Functions;

$frontend= new Frontend($handler, new Handlebars($this->environment->path('src/main/handlebars'), [
  new Functions([
    'top' => fn($node, $context, $options) => array_slice($options[1], 0, $options[0])
  ])
]);
```

Handlebars:

```handlebars
{{#each (top 3 comments)}}
  ...
{{/each}}
```

The parameters to these helper functions are the following:

* **node:** The current node, a `com.github.mustache.Node` instance
* **context:** The current context, a `com.github.mustache.Context` instance
* **options:** The resolved options passed, in the above example: `[scalar(3), resolve(comments)]`