### PR TITLE
Allow passing maps to extensions

### DIFF
--- a/src/main/php/web/frontend/Handlebars.class.php
+++ b/src/main/php/web/frontend/Handlebars.class.php
@@ -24,7 +24,7 @@ class Handlebars implements Templates {
    * either a reference to a filesystem path, or using an in-memory loader 
    *
    * @param  string|io.Path|io.Folder|com.github.mustache.TemplateLoader $templates 
-   * @param  web.frontend.helpers.Extension[] $extensions
+   * @param  [:var][]|web.frontend.helpers.Extension[] $extensions
    */
   public function __construct($templates, array $extensions= []) {
     $this->backing= (new HandlebarsEngine(self::$parser))
@@ -44,9 +44,14 @@ class Handlebars implements Templates {
     }
   }
 
-  /** Adds helpers from the given extension */
-  public function using(Extension $extension): self {
-    foreach ($extension->helpers() as $name => $function) {
+  /**
+   * Adds helpers from the given extension
+   *
+   * @param  [:var]|web.frontend.helpers.Extension $extension
+   */
+  public function using($extension): self {
+    $it= $extension instanceof Extension ? $extension->helpers() : $extension;
+    foreach ($it as $name => $function) {
       $this->backing->withHelper($name, $function);
     }
     return $this;

--- a/src/test/php/web/frontend/unittest/ExtensionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/ExtensionsTest.class.php
@@ -1,0 +1,32 @@
+<?php namespace web\frontend\unittest;
+
+use unittest\{Assert, Test, Values};
+
+class ExtensionsTest extends HandlebarsTest {
+
+  /** @return web.frontend.Extension[] */
+  protected function extensions() {
+    return [[
+      'scalar'   => 'test',
+      'map'      => ['test' => 'works'],
+      'function' => function($in, $context, $options) {
+        return strtoupper($options[0]);
+      }
+    ]];
+  }
+
+  #[Test]
+  public function bound_scalar() {
+    Assert::equals('test', $this->transform('{{scalar}}'));
+  }
+
+  #[Test]
+  public function bound_map() {
+    Assert::equals('works', $this->transform('{{map.test}}'));
+  }
+
+  #[Test]
+  public function bound_function() {
+    Assert::equals('TEST', $this->transform('{{function "test"}}'));
+  }
+}


### PR DESCRIPTION
## Current code

The *extensions* argument had to be an array of `web.frontend-helpers.Extension` instances.

```php
new Handlebars($this->environment->path('src/main/handlebars'), [
  new Dates(TimeZone::getByName('Europe/Berlin')),
  new class() extends Extension {
    public function helpers() {
      yield 'service' => function($in, $context, $options) {
        return $context->lookup('request')->uri()->base();
      };
    }
  }
]);
```

## New code

We can now substantially shorten the above example:

```php
new Handlebars($this->environment->path('src/main/handlebars'), [
  new Dates(TimeZone::getByName('Europe/Berlin')),
  ['service' => fn($in, $context, $options) => $context->lookup('request')->uri()->base()]
]);
```