### PR TITLE
Add render() method which returns the result as a string

### DIFF
--- a/src/main/php/web/frontend/Handlebars.class.php
+++ b/src/main/php/web/frontend/Handlebars.class.php
@@ -58,14 +58,26 @@ class Handlebars implements Templates {
   }
 
   /**
-   * Transforms a named template
+   * Transforms a named template and returns the result as a string.
+   *
+   * @param  string $name Template name
+   * @param  [:var] $context
+   * @return string
+   */
+  public function render($name, $context) {
+    return $this->backing->evaluate($this->backing->load($name), $context + ['scope' => $name]);
+  }
+
+  /**
+   * Transforms a named template, writing the result to a given output stream.
    *
    * @param  string $name Template name
    * @param  [:var] $context
    * @param  io.streams.OutputStream $out
-   * @return void
+   * @return io.streams.OutputStream
    */
   public function write($name, $context, $out) {
     $this->backing->write($this->backing->load($name), $context + ['scope' => $name], $out);
+    return $out;
   }
 }

--- a/src/test/php/web/frontend/unittest/ClassTest.class.php
+++ b/src/test/php/web/frontend/unittest/ClassTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\unittest;
 
+use io\streams\MemoryOutputStream;
 use test\{Assert, Test};
 use web\frontend\Handlebars;
 
@@ -13,6 +14,24 @@ class ClassTest extends HandlebarsTest {
   #[Test]
   public function can_create_with_path() {
     new Handlebars('src/main/handlebars');
+  }
+
+  #[Test]
+  public function render() {
+    $fixture= new Handlebars($this->templates->add('fixture', '<h1>Hello @{{user}}!</h1>'));
+    Assert::equals(
+      '<h1>Hello @test!</h1>',
+      $fixture->render('fixture', ['user' => 'test'])
+    );
+  }
+
+  #[Test]
+  public function write() {
+    $fixture= new Handlebars($this->templates->add('fixture', '<h1>Hello @{{user}}!</h1>'));
+    Assert::equals(
+      '<h1>Hello @test!</h1>',
+      $fixture->write('fixture', ['user' => 'test'], new MemoryOutputStream())->bytes()
+    );
   }
 
   #[Test]

--- a/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlebarsTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace web\frontend\unittest;
 
 use com\github\mustache\InMemory;
-use io\streams\MemoryOutputStream;
 use web\frontend\Handlebars;
 
 abstract class HandlebarsTest {
@@ -24,9 +23,7 @@ abstract class HandlebarsTest {
    * @return string
    */
   protected function transform($template, $context= []) {
-    $out= new MemoryOutputStream();
     $fixture= new Handlebars($this->templates->add('fixture', $template), $this->extensions());
-    $fixture->write('fixture', $context, $out);
-    return $out->bytes();
+    return $fixture->render('fixture', $context);
   }
 }


### PR DESCRIPTION
This pull request adds a `render()` method to `web.frontend.Handlebars`. This can be used e.g. for rendering partials inside a REST API.

## Before

```php
use io\streams\MemoryOutputStream;
use web\frontend\Handlebars;

$out= new MemoryOutputStream();
$fixture= new Handlebars($templates);
$fixture->write('fixture', $context, $out);
$rendered= $out->bytes();
```

## After

```php
use web\frontend\Handlebars;

$fixture= new Handlebars($templates);
$rendered= $fixture->render('fixture', $context);
```