### PR TITLE
Implement fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,26 +61,25 @@ nav:
 
 Fragments
 ---------
-Instead of rendering an entire template, we can render inline partials declared as follows:
+Instead of rendering an entire template, we can render special inline partials we call *fragments*. They are declared as follows:
 
 ```handlebars
 <!DOCTYPE html>
 <html lang="en">
   <head>...</head>
   <body>
-    {{#*inline "listing"}}
+    {{#*fragment "listing"}}
       <ul>
         {{#each items}}
           <li>{{.}}</li>
         {{/each}}
       </ul>
-    {{/inline}}
-    {{> listing}}
+    {{/fragment}}
   </body>
 </html>
 ```
 
-...by selecting them via *fragment()* in our handler:
+...and are rendered by selecting them via *fragment()* in our handler:
 
 ```php
 use web\frontend\{Handler, Get};

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0",
     "xp-forge/frontend": "^5.0 | ^4.0 | ^3.0 | ^2.0",
-    "xp-forge/handlebars": "^9.0",
+    "xp-forge/handlebars": "^9.1",
     "xp-forge/yaml": "^6.0",
     "php": ">=7.0.0"
   },

--- a/src/main/php/web/frontend/TemplateParser.class.php
+++ b/src/main/php/web/frontend/TemplateParser.class.php
@@ -15,14 +15,12 @@ class TemplateParser extends HandlebarsParser {
   private static $yaml;
 
   /**
-   * Initialize this parser.
+   * Initialize this parser, adding support for fragments.
    *
    * @return void
    */
   protected function initialize() {
     parent::initialize();
-
-    // Fragments are instantly-invoked inline partials
     $this->blocks->register('*fragment', function($options, $state) {
       $name= $options[0] instanceof Quoted ? $options[0]->chars : $options[0];
       $state->target->add(new PartialBlockHelper([$name]));

--- a/src/main/php/web/frontend/TemplateParser.class.php
+++ b/src/main/php/web/frontend/TemplateParser.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\frontend;
 
 use com\github\mustache\TemplateFormatException;
-use com\handlebarsjs\HandlebarsParser;
+use com\handlebarsjs\{HandlebarsParser, BlockNode, Quoted, PartialBlockHelper};
 use org\yaml\{YamlParser, StringInput};
 use text\Tokenizer;
 
@@ -13,6 +13,22 @@ use text\Tokenizer;
  */
 class TemplateParser extends HandlebarsParser {
   private static $yaml;
+
+  /**
+   * Initialize this parser.
+   *
+   * @return void
+   */
+  protected function initialize() {
+    parent::initialize();
+
+    // Fragments are instantly-invoked inline partials
+    $this->blocks->register('*fragment', function($options, $state) {
+      $name= $options[0] instanceof Quoted ? $options[0]->chars : $options[0];
+      $state->target->add(new PartialBlockHelper([$name]));
+      return new BlockNode('fragment', [], $state->parents[0]->declare($name));
+    });
+  }
 
   /**
    * Parse a template

--- a/src/test/php/web/frontend/unittest/InlineTest.class.php
+++ b/src/test/php/web/frontend/unittest/InlineTest.class.php
@@ -31,4 +31,13 @@ class InlineTest extends HandlebarsTest {
   public function non_existant($inline) {
     $this->transform($inline, null, 'non-existant');
   }
+
+  #[Test]
+  public function fragment() {
+    $template= 'Test: {{#*fragment "items"}}{{#each items}}* {{.}} {{/each}}{{/fragment}}';
+    Assert::equals(
+      'Test: * One * Two ',
+      $this->transform($template, ['items' => ['One', 'Two']])
+    );
+  }
 }


### PR DESCRIPTION
These can be thought of as "instantly-invoked inline partials". The following two are equivalent:

**1) An inline partial** (as [defined by Handlebars](https://handlebarsjs.com/guide/partials.html#inline-partials)) followed by calling it directly:

```handlebars
{{#*inline "items"}}
  {{#each items}}* {{.}} {{/each}}
{{/inline}}
{{> items}}
```

**2) The fragment version** we're introducing with this pull request:

```handlebars
{{#*fragment "items"}}
  {{#each items}}* {{.}} {{/each}}
{{/fragment}}
```