### PR TITLE
Implement `coalesce` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ On top of the [built-in functionality in Handlebars](https://github.com/xp-forge
 * `any`: Test whether any of the given arguments is truthy
 * `none`: Test whether none of the given arguments is truthy
 * `all`: Test whether all of the given arguments is truthy
+* `coalesce`: Returns the first non-null argument
 
 ### Date handling
 

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -61,5 +61,11 @@ class Essentials extends Extension {
       }
       return empty($options) ? 0 : 1;
     };
+    yield 'coalesce' => function($in, $context, $options) {
+      foreach ($options as $option) {
+        if (isset($option)) return $option;
+      }
+      return null;
+    };
   }
 }

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -86,4 +86,12 @@ class EssentialsTest extends HandlebarsTest {
       'empty'   => [],
     ]));
   }
+
+  #[Test, Values([[[], 'Default'], [['title' => null], 'Default'], [['title' => 'Test'], 'Test']])]
+  public function coalesce($context, $outcome) {
+    Assert::equals(
+      $outcome,
+      $this->transform('{{coalesce title "Default"}}', $context)
+    );
+  }
 }


### PR DESCRIPTION
This pull request adds a helper which returns the first non-null argument.

```handlebars
This syntax:
{{#title}}{{.}}{{^}}Default{{/title}}

Can now be shortened to:
{{coalesce title "Default"}}
```

This is similar to the `any` helper but it returns the first non-null value (*or `null` if there is none*) instead of `true` or `false`.