### PR TITLE
Support nested fragments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0",
     "xp-forge/frontend": "^5.0 | ^4.0 | ^3.0 | ^2.0",
-    "xp-forge/handlebars": "^9.1",
+    "xp-forge/handlebars": "^9.3",
     "xp-forge/yaml": "^6.0",
     "php": ">=7.0.0"
   },

--- a/src/main/php/web/frontend/Handlebars.class.php
+++ b/src/main/php/web/frontend/Handlebars.class.php
@@ -57,8 +57,9 @@ class Handlebars implements Templates {
     $template= $this->backing->load($name);
     if (null === $fragment) return $template;
 
-    if ($nodes= $template->root()->partial($fragment)) {
-      return new Template($fragment, $nodes);
+    $parent= $template->root();
+    if ($nodes= $parent->partial($fragment)) {
+      return new Template($fragment, $nodes->inheriting($parent));
     }
 
     throw new TemplateNotFoundException('No such fragment "'.$fragment.'" in template "'.$name.'"');

--- a/src/test/php/web/frontend/unittest/InlineTest.class.php
+++ b/src/test/php/web/frontend/unittest/InlineTest.class.php
@@ -40,4 +40,13 @@ class InlineTest extends HandlebarsTest {
       $this->transform($template, ['items' => ['One', 'Two']])
     );
   }
+
+  #[Test]
+  public function nested_fragment() {
+    $template= 'Test: {{#*fragment "items"}}{{#each items}}{{#*fragment "item"}}* {{.}}{{/fragment}} {{/each}}{{/fragment}}';
+    Assert::equals(
+      '* One * Two ',
+      $this->transform($template, ['items' => ['One', 'Two']], 'items')
+    );
+  }
 }


### PR DESCRIPTION
This PR supports `{{#*fragment}}` inside fragments.

Requires https://github.com/xp-forge/handlebars/pull/30 