### PR TITLE
Add support for fragment parameters

### DIFF
--- a/src/main/php/web/frontend/TemplateParser.class.php
+++ b/src/main/php/web/frontend/TemplateParser.class.php
@@ -23,7 +23,7 @@ class TemplateParser extends HandlebarsParser {
     parent::initialize();
     $this->blocks->register('*fragment', function($options, $state) {
       $name= $options[0] instanceof Quoted ? $options[0]->chars : $options[0];
-      $state->target->add(new PartialBlockHelper([$name]));
+      $state->target->add(new PartialBlockHelper([$name] + $options));
       return new BlockNode('fragment', [], $state->parents[0]->declare($name));
     });
   }

--- a/src/test/php/web/frontend/unittest/InlineTest.class.php
+++ b/src/test/php/web/frontend/unittest/InlineTest.class.php
@@ -34,6 +34,15 @@ class InlineTest extends HandlebarsTest {
 
   #[Test]
   public function fragment() {
+    $template= 'Test: {{#*fragment "item"}}{{key}}{{/fragment}}';
+    Assert::equals(
+      'Test: value',
+      $this->transform($template, ['key' => 'value'])
+    );
+  }
+
+  #[Test]
+  public function fragment_around_each() {
     $template= 'Test: {{#*fragment "items"}}{{#each items}}* {{.}} {{/each}}{{/fragment}}';
     Assert::equals(
       'Test: * One * Two ',
@@ -42,11 +51,37 @@ class InlineTest extends HandlebarsTest {
   }
 
   #[Test]
+  public function fragment_inside_each() {
+    $template= 'Test: {{#each items}}{{#*fragment "item"}}* {{.}} {{/fragment}}{{/each}}';
+    Assert::equals(
+      'Test: * One * Two ',
+      $this->transform($template, ['items' => ['One', 'Two']])
+    );
+  }
+
+  #[Test]
   public function nested_fragment() {
-    $template= 'Test: {{#*fragment "items"}}{{#each items}}{{#*fragment "item"}}* {{.}}{{/fragment}} {{/each}}{{/fragment}}';
+    $template=
+      'Test: {{#*fragment "items"}}'.
+      '{{#each items}}{{#*fragment "item"}}* {{.}}{{/fragment}} {{/each}}'.
+      '{{/fragment}}'
+    ;
     Assert::equals(
       '* One * Two ',
       $this->transform($template, ['items' => ['One', 'Two']], 'items')
+    );
+  }
+
+  #[Test]
+  public function fragment_parameters() {
+    $template=
+      'Test: {{#*fragment "items" select=items separator=", "}}'.
+      '{{#each select}}{{.}}{{#unless @last}}{{separator}}{{/unless}}{{/each}}'.
+      '{{/fragment}}'
+    ;
+    Assert::equals(
+      'Test: One, Two',
+      $this->transform($template, ['items' => ['One', 'Two']])
     );
   }
 }

--- a/src/test/php/web/frontend/unittest/InlineTest.class.php
+++ b/src/test/php/web/frontend/unittest/InlineTest.class.php
@@ -33,6 +33,20 @@ class InlineTest extends HandlebarsTest {
   }
 
   #[Test]
+  public function parameters() {
+    $template=
+      'Test: {{#*inline "items"}}'.
+      '{{#each select}}{{.}}{{#unless @last}}{{separator}}{{/unless}}{{/each}}'.
+      '{{/inline}}'.
+      '{{> items select=items separator=", "}}'
+    ;
+    Assert::equals(
+      'Test: One, Two',
+      $this->transform($template, ['items' => ['One', 'Two']])
+    );
+  }
+
+  #[Test]
   public function fragment() {
     $template= 'Test: {{#*fragment "item"}}{{key}}{{/fragment}}';
     Assert::equals(


### PR DESCRIPTION
This PR allows passing parameters to fragments, which are then passed to the fragment during execution.

```handlebars
{{#*fragment "items" select=items separator=", "}}
  {{#each select}}
    {{.}}{{#unless @last}}{{separator}}{{/unless}}
  {{/each}}
{{/fragment}}
```