### PR TITLE
Add `json` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Helpers
 On top of the [built-in functionality in Handlebars](https://github.com/xp-forge/handlebars), this library includes the following essential helpers:
 
 * `encode`: Performs URL-encoding 
+* `json`: Performs JSON encoding, pretty-printing when given `format=true`.
 * `equals`: Tests arguments for equality
 * `contains`: Tests whether a string or array contains a certain value
 * `size`: Returns string length or array size

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "xp-forge/frontend": "^7.0 | ^6.0",
     "xp-forge/handlebars": "^10.0 | ^9.3",
     "xp-forge/yaml": "^9.0 | ^8.0 | ^7.0 | ^6.0",
+    "xp-forge/json": "^6.0 | ^5.0",
     "php": ">=7.4.0"
   },
   "require-dev" : {

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\helpers;
 
+use Countable;
 use text\json\{StringOutput, Format};
 use util\data\Marshalling;
 
@@ -33,7 +34,7 @@ class Essentials extends Extension {
     yield 'size' => function($in, $context, $options) {
       if (!isset($options[0])) {
         return 0;
-      } else if ($options[0] instanceof \Countable || is_array($options[0])) {
+      } else if ($options[0] instanceof Countable || is_array($options[0])) {
         return sizeof($options[0]);
       } else {
         return strlen($options[0]);

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\frontend\helpers;
 
 use text\json\{StringOutput, Format};
+use util\data\Marshalling;
 
 /** Built-in and automatically loaded essentials */
 class Essentials extends Extension {
@@ -11,9 +12,10 @@ class Essentials extends Extension {
       return rawurlencode($options[0] ?? '');
     };
     yield 'json' => function($in, $context, $options) {
-      static $format;
+      static $marshalling, $format;
+
       $s= new StringOutput(($options['format'] ?? false) ? ($format??= Format::wrapped('  ')) : Format::$DEFAULT);
-      $s->write($options[0] ?? null);
+      $s->write(($marshalling??= new Marshalling())->marshal($options[0] ?? null));
       return $s->bytes();
     };
     yield 'equals' => function($in, $context, $options) {

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -1,5 +1,7 @@
 <?php namespace web\frontend\helpers;
 
+use text\json\{StringOutput, Format};
+
 /** Built-in and automatically loaded essentials */
 class Essentials extends Extension {
 
@@ -9,7 +11,10 @@ class Essentials extends Extension {
       return rawurlencode($options[0] ?? '');
     };
     yield 'json' => function($in, $context, $options) {
-      return json_encode($options[0] ?? null, ($options['format'] ?? false) ? JSON_PRETTY_PRINT : 0);
+      static $format;
+      $s= new StringOutput(($options['format'] ?? false) ? ($format??= Format::wrapped('  ')) : Format::$DEFAULT);
+      $s->write($options[0] ?? null);
+      return $s->bytes();
     };
     yield 'equals' => function($in, $context, $options) {
       return (int)(($options[0] ?? null) === ($options[1] ?? null));

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -9,7 +9,7 @@ class Essentials extends Extension {
       return rawurlencode($options[0] ?? '');
     };
     yield 'json' => function($in, $context, $options) {
-      return json_encode($options[0] ?? null, isset($options['format']) ? JSON_PRETTY_PRINT : 0);
+      return json_encode($options[0] ?? null, ($options['format'] ?? false) ? JSON_PRETTY_PRINT : 0);
     };
     yield 'equals' => function($in, $context, $options) {
       return (int)(($options[0] ?? null) === ($options[1] ?? null));

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -8,6 +8,9 @@ class Essentials extends Extension {
     yield 'encode' => function($in, $context, $options) {
       return rawurlencode($options[0] ?? '');
     };
+    yield 'json' => function($in, $context, $options) {
+      return json_encode($options[0] ?? null, isset($options['format']) ? JSON_PRETTY_PRINT : 0);
+    };
     yield 'equals' => function($in, $context, $options) {
       return (int)(($options[0] ?? null) === ($options[1] ?? null));
     };

--- a/src/main/php/web/frontend/helpers/Essentials.class.php
+++ b/src/main/php/web/frontend/helpers/Essentials.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\frontend\helpers;
 
 use Countable;
-use text\json\{StringOutput, Format};
+use text\json\{StringOutput, WrappedFormat};
 use util\data\Marshalling;
 
 /** Built-in and automatically loaded essentials */
@@ -15,7 +15,7 @@ class Essentials extends Extension {
     yield 'json' => function($in, $context, $options) {
       static $marshalling, $format;
 
-      $s= new StringOutput(($options['format'] ?? false) ? ($format??= Format::wrapped('  ')) : Format::$DEFAULT);
+      $s= new StringOutput(($options['format'] ?? false) ? ($format??= new WrappedFormat('  ')) : null);
       $s->write(($marshalling??= new Marshalling())->marshal($options[0] ?? null));
       return $s->bytes();
     };

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -12,6 +12,42 @@ class EssentialsTest extends HandlebarsTest {
     );
   }
 
+  #[Test]
+  public function json_string() {
+    Assert::equals(
+      'let str = "He said \\"hello \\u4e16\\u754c!\\"\\n";',
+      $this->transform('let str = {{&json input}};', ['input' => 'He said "hello 世界!"'."\n"])
+    );
+  }
+
+  #[Test]
+  public function json_object() {
+    Assert::equals(
+      'let obj = {"hello":["World",true]};',
+      $this->transform('let obj = {{&json input}};', ['input' => ['hello' => ['World', true]]])
+    );
+  }
+
+  #[Test]
+  public function formatted_json() {
+    Assert::equals(
+      <<<'JSON'
+      {
+          "hello": [
+              "World",
+              true
+          ]
+      }
+      JSON,
+      $this->transform('{{&json input format=true}}', ['input' => ['hello' => ['World', true]]])
+    );
+  }
+
+  #[Test, Values([['</script>', '"<\\/script>"'], ['// END', '"\\/\\/ END"']])]
+  public function forward_slashes_escaped($input, $expected) {
+    Assert::equals($expected, $this->transform('{{&json input}}', ['input' => $input]));
+  }
+
   #[Test, Values(['{{equals "A" "A"}}', '{{equals "A" a}}', '{{equals a a}}'])]
   public function are_equal($template) {
     Assert::equals('1', $this->transform($template, ['a' => 'A']));

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -57,7 +57,7 @@ class EssentialsTest extends HandlebarsTest {
     );
   }
 
-  #[Test, Values([['</script>', '"<\\/script>"'], ['// END', '"\\/\\/ END"']])]
+  #[Test, Values([['</script>', '"<\\/script>"'], ['// END', '"\\/\\/ END"'], [['tag' => '</a>'], '{"tag":"<\\/a>"}']])]
   public function forward_slashes_escaped($input, $expected) {
     Assert::equals($expected, $this->transform('{{&json input}}', ['input' => $input]));
   }

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -1,8 +1,21 @@
 <?php namespace web\frontend\unittest;
 
+use ArrayIterator;
 use test\{Assert, Test, Values};
 
 class EssentialsTest extends HandlebarsTest {
+
+  /** @return iterable */
+  private function objects() {
+    yield [['hello' => ['World', true]]];
+    yield [new class() { public $hello= ['World', true]; }];
+  }
+
+  /** @return iterable */
+  private function iterables() {
+    yield [(function() { yield 1; yield 2; yield 3; })()];
+    yield [new ArrayIterator([1, 2, 3])];
+  }
 
   #[Test]
   public function url_encode() {
@@ -20,20 +33,19 @@ class EssentialsTest extends HandlebarsTest {
     );
   }
 
-  #[Test]
-  public function json_object() {
+  #[Test, Values(from: 'objects')]
+  public function json_object($object) {
     Assert::equals(
       'let obj = {"hello":["World",true]};',
-      $this->transform('let obj = {{&json input}};', ['input' => ['hello' => ['World', true]]])
+      $this->transform('let obj = {{&json input}};', ['input' => $object])
     );
   }
 
-  #[Test]
-  public function json_iterable() {
-    $numbers= function() { yield 1; yield 2; yield 3; };
+  #[Test, Values(from: 'iterables')]
+  public function json_iterable($iterable) {
     Assert::equals(
       'let it = [1,2,3];',
-      $this->transform('let it = {{&json input}};', ['input' => $numbers()])
+      $this->transform('let it = {{&json input}};', ['input' => $iterable])
     );
   }
 

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -29,16 +29,18 @@ class EssentialsTest extends HandlebarsTest {
   }
 
   #[Test]
+  public function json_iterable() {
+    $numbers= function() { yield 1; yield 2; yield 3; };
+    Assert::equals(
+      'let it = [1,2,3];',
+      $this->transform('let it = {{&json input}};', ['input' => $numbers()])
+    );
+  }
+
+  #[Test]
   public function formatted_json() {
     Assert::equals(
-      <<<'JSON'
-      {
-          "hello": [
-              "World",
-              true
-          ]
-      }
-      JSON,
+      "{\n  \"hello\": [\"World\", true]\n}",
       $this->transform('{{&json input format=true}}', ['input' => ['hello' => ['World', true]]])
     );
   }

--- a/src/test/php/web/frontend/unittest/EssentialsTest.class.php
+++ b/src/test/php/web/frontend/unittest/EssentialsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\frontend\unittest;
 
-use ArrayIterator;
+use ArrayIterator, Countable;
 use test\{Assert, Test, Values};
 
 class EssentialsTest extends HandlebarsTest {
@@ -94,7 +94,7 @@ class EssentialsTest extends HandlebarsTest {
       'test'    => 'Test',
       'numbers' => [1, 2, 3],
       'sizes'   => ['S' => 12.99, 'M' => 13.99],
-      'count'   => new class() implements \Countable { public function count(): int { return 1; } },
+      'count'   => new class() implements Countable { public function count(): int { return 1; } },
       'empty'   => [],
     ]));
   }


### PR DESCRIPTION
This helper can be used to transport values from PHP to JavaScript:

```handlebars
<script>
  let person = {{&json person}};
  console.log(person.name);
</script>
```

* [x] Takes care of quoting and escaping strings
* [x] Escapes forward slashes to prevent parsing [problems with closing script tags inside strings](https://stackoverflow.com/questions/22488830/script-within-a-javascript-string-in-a-script-tag)
* [x] Has an option `format=true` to pretty-print the JSON

See also https://stackoverflow.com/questions/10232574/need-handlebars-js-to-render-object-data-instead-of-object-object and https://laravel.com/docs/master/blade#rendering-json